### PR TITLE
Bugfix/content type hierarchy comment

### DIFF
--- a/client/Assets/Examples/Runtime/Services/ContentService/ContentValidationExample/Scripts/ComplexItem.cs
+++ b/client/Assets/Examples/Runtime/Services/ContentService/ContentValidationExample/Scripts/ComplexItem.cs
@@ -16,7 +16,9 @@ namespace Beamable.Examples.Services.ContentService
     /// Using validation is optional.
     ///
     /// See "Beamable.Common.Content.Validation" for full list.
-    /// 
+    ///
+    /// The content type for this class will be "items.complex_item", nested
+    /// under the "items" content type.
     /// </summary>
     [ContentType("complex_item")]
     public class ComplexItem : ItemContent
@@ -26,7 +28,7 @@ namespace Beamable.Examples.Services.ContentService
         /// </summary>
         [CannotBeBlank]
         public string Name = "";
-        
+
         /// <summary>
         /// Custom: Validation requires that the value be string and of
         /// string length of 2 or 3.
@@ -34,7 +36,7 @@ namespace Beamable.Examples.Services.ContentService
         /// </summary>
         [MustBeStringLength (2, 3)]
         public string FavoriteLetters = "";
-        
+
         /// <summary>
         /// Built-in: Validation requires that the value be positive and
         /// non-zero.

--- a/client/Assets/Examples/Runtime/Shared/Scripts/Armor.cs
+++ b/client/Assets/Examples/Runtime/Shared/Scripts/Armor.cs
@@ -6,13 +6,17 @@ namespace Beamable.Examples.Shared
 {
     [Serializable]
     public class ArmorLink : ContentLink<Armor> {}
-    
+
     [Serializable]
     public class ArmorRef : ContentRef<Armor> {}
-    
+
     /// <summary>
     /// This type defines a custom ItemContent for use in
-    /// several example scenes
+    /// several example scenes.
+    ///
+    /// Note that content types are hierarchical. Because this is a subclass of
+    /// ItemContent, it also inherits "items" as a parent content type. The
+    /// resulting content type will be "items.armor", nested under "items".
     /// </summary>
     [ContentType("armor")]
     public class Armor : ItemContent


### PR DESCRIPTION
Simple additions to doc comments for content types to hopefully reduce confusion about where custom content types appear when they inherit from existing content types.